### PR TITLE
Remove duplicate footer text

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,12 +120,7 @@
       <a href="privacy.html">Privacy Policy</a>
       <a href="terms.html">Terms of Service</a>
     </nav>
-    <p>&copy; 2026 Study Task Tracker</p>
-  </footer>
-
-
-  <footer>
-    <p>© 2026 Study Tracker | Made for students</p>
+    <p>&copy; 2026 Study Task Tracker | Made for students</p>
   </footer>
 
   <script src="script.js"></script>


### PR DESCRIPTION
### Fix: Remove duplicate footer text

**Description:**
This PR removes the duplicate copyright/footer text displayed in the UI.

**Changes Made:**

* Removed redundant footer text
* Kept a single consistent copyright section

**Screenshots:**

Before:
<img width="600" height="172" alt="Screenshot 2026-05-08 195539" src="https://github.com/user-attachments/assets/ee228103-5858-4cfd-ab01-9da7d7ebbd3f" />


After:
<img width="559" height="193" alt="Screenshot 2026-05-08 200551" src="https://github.com/user-attachments/assets/e235fc6d-5699-4ffd-9a57-27040b7bb87c" />


**Reason:**
The footer previously displayed two similar copyright-related texts, which created unnecessary duplication and affected visual consistency.

**Result:**

* Cleaner footer UI
* Improved visual consistency
* Reduced redundancy in the layout
