### PR TITLE
docs: add Contributor Covenant Code of Conduct v2.1

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.


### PR DESCRIPTION
# Related Issue
Closes #316 #344 

# Summary
# Summary
Adds the standard `CODE_OF_CONDUCT.md` to establish clear behavioral expectations and enforcement guidelines for all TaskQuest contributors.

# Changes Made
- Created `CODE_OF_CONDUCT.md` based on Contributor Covenant v2.1
- Covers: pledge, positive/negative behavior examples, enforcement responsibilities, scope, reporting process, 4-tier enforcement guidelines (Correction / Warning / Temporary Ban / Permanent Ban)
- Adapted for the Student Task Manager community context

# Testing
- Verified Markdown renders correctly on GitHub

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
