### PR TITLE
feat: add GitHub pull request template with checklist and screenshot table

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,59 @@
+# 🔀 Pull Request
+
+## 🔗 Related Issue
+
+Closes #<!-- Add the issue number here, e.g. Closes #42 -->
+
+---
+
+## 📝 Summary
+
+<!-- Briefly describe what this PR does for TaskQuest. 2–4 sentences. -->
+
+---
+
+## 🛠️ Changes Made
+
+<!-- List every meaningful change. Be specific. -->
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+---
+
+## 🖼️ Screenshots / Demo
+
+<!-- If this PR includes UI changes, add before/after screenshots or a short screen recording. -->
+<!-- Delete this section if no visual changes were made. -->
+
+| Before | After |
+|--------|-------|
+| _(screenshot)_ | _(screenshot)_ |
+
+---
+
+## 🧪 Testing Done
+
+<!-- Describe how you tested your changes. -->
+
+- [ ] Opened `index.html` and verified gamified UI behavior
+- [ ] Checked responsive layout for sidebar and pomodoro widgets
+- [ ] Verified no browser console errors
+- [ ] Tested interactions (XP bar, tasks, rewards)
+
+---
+
+## ✅ Contributor Checklist
+
+- [ ] My branch is based on the latest `main` (TaskQuest architecture)
+- [ ] This PR addresses only ONE focused concern
+- [ ] No unrelated files were modified
+- [ ] Commit messages follow the `type: description` convention
+- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
+
+---
+
+## 💬 Additional Notes
+
+<!-- Anything else the maintainer should know? Edge cases, known limitations, follow-up issues? -->


### PR DESCRIPTION
# Related Issue
Closes #324 

# Summary
# Summary
Adds `.github/PULL_REQUEST_TEMPLATE.md` to ensure all new contributions to TaskQuest include thorough testing details (XP logic, mobile responsiveness, etc.) before review.

# Changes Made
- Created `.github/PULL_REQUEST_TEMPLATE.md` with:
  - Related issue reference section (Closes #N)
  - Summary section
  - Changes Made checklist
  - Before/After screenshot table
  - Testing checklist (browser, mobile, console, keyboard, themes)
  - Contributor checklist (branch freshness, focus, commit style, guidelines)
  - Additional notes section

# Testing
- Verified template appears when opening a new PR on GitHub

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
