### PR TITLE
Feat/add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: 🐛 Bug Report
+about: Report a bug or unexpected behavior in TaskQuest
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+assignees: []
+---
+
+## 🐛 Bug Description
+
+<!-- A clear and concise description of the bug. -->
+
+## 🔁 Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Observe that '...'
+
+## ✅ Expected Behavior
+
+<!-- What did you expect to happen? -->
+
+## ❌ Actual Behavior
+
+<!-- What actually happened instead? -->
+
+## 📸 Screenshots
+
+<!-- If applicable, add screenshots to help explain the problem. -->
+
+## 🌐 Environment
+
+- **Browser**: <!-- e.g. Chrome 123, Firefox 124 -->
+- **OS**: <!-- e.g. Windows 11, macOS 14, Ubuntu 22.04 -->
+- **Theme active**: <!-- Light / Dark -->
+
+## 📋 Additional Context
+
+<!-- Any other context about the problem here (e.g., console errors, specific task text that triggers the issue). -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,39 @@
+---
+name: ✨ Feature Request
+about: Suggest a new feature or improvement for TaskQuest
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees: []
+---
+
+## 🚀 Feature Description
+
+<!-- A clear and concise description of the feature you'd like to see. -->
+
+## 🎯 Problem it Solves
+
+<!-- Is your feature request related to a problem? Describe it. -->
+<!-- e.g. "As a student, I find it hard to X because..." -->
+
+## 💡 Proposed Solution
+
+<!-- Describe the solution you'd like. Be as specific as possible. -->
+
+## 🔄 Alternatives Considered
+
+<!-- Describe any alternative solutions or features you've considered. -->
+
+## 📸 Mockup / Example
+
+<!-- If applicable, add a mockup, screenshot, or reference to illustrate the idea. -->
+
+## 📋 Additional Context
+
+<!-- Add any other context or information about the feature request here. -->
+
+---
+
+**Checklist before submitting:**
+- [ ] I searched existing issues and this feature hasn't been requested before.
+- [ ] This is a single, focused feature request.
+- [ ] I'm willing to contribute this feature if assigned.


### PR DESCRIPTION
# Related Issue
Closes #326 

# Summary
# Summary
Adds structured `bug_report.md` and `feature_request.md` templates to `.github/ISSUE_TEMPLATE` to enforce better context gathering when users report issues with TaskQuest features.

# Changes Made
- Created `.github/ISSUE_TEMPLATE/bug_report.md` with sections: description, steps to reproduce, expected/actual behavior, screenshots, environment (browser/OS/theme), additional context. Labels: `bug`, `needs-triage`
- Created `.github/ISSUE_TEMPLATE/feature_request.md` with sections: feature description, problem solved, proposed solution, alternatives considered, mockup, checklist. Label: `enhancement`

# Testing
- Verified YAML frontmatter is valid
- Confirmed templates render correctly on GitHub

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
