### PR TITLE
fix: unified versioned localStorage schema (taskquest_v1)

### DIFF
--- a/Challenge.html
+++ b/Challenge.html
@@ -93,6 +93,7 @@
 
 </div>
 
+<script src="storage.js"></script>
 <script src="Challenge.js"></script>
 </body>
 </html>

--- a/Challenge.js
+++ b/Challenge.js
@@ -40,6 +40,28 @@ let state = {
   usedIndices: [],
 };
 
+// ── Persistence helpers ───────────────────────────────────────────────────
+function saveState() {
+  try {
+    if (window.TaskQuestStorage) {
+      window.TaskQuestStorage.setChallenge(state);
+    } else {
+      localStorage.setItem("taskquest_v1.challenge", JSON.stringify(state));
+    }
+  } catch (e) { /* storage full — ignore */ }
+}
+
+function loadState() {
+  try {
+    const saved = window.TaskQuestStorage
+      ? window.TaskQuestStorage.getChallenge()
+      : JSON.parse(localStorage.getItem("taskquest_v1.challenge"));
+    if (saved && typeof saved === "object") {
+      state = Object.assign(state, saved);
+    }
+  } catch (e) { /* corrupt data — use defaults */ }
+}
+
 function generateChallenge() {
   const btn = document.getElementById("randomBtn");
   btn.classList.add("spinning");
@@ -69,6 +91,7 @@ function generateChallenge() {
   card.classList.remove("hidden");
 
   addToActive(state.currentChallenge);
+  saveState();
 }
 
 function addToActive(challenge) {
@@ -109,6 +132,7 @@ function handleResponse() {
     checkBadges();
     renderActiveChallenges();
     renderCompletedChallenges();
+    saveState();
 
     setTimeout(() => {
       document.getElementById("challenge-card").classList.add("hidden");
@@ -189,3 +213,10 @@ function renderCompletedChallenges() {
 document.getElementById("user-input").addEventListener("keydown", function(e) {
   if (e.key === "Enter") handleResponse();
 });
+
+// ── Boot: restore persisted state ────────────────────────────────────────
+loadState();
+updatePoints();
+checkBadges();
+renderActiveChallenges();
+renderCompletedChallenges();

--- a/Reflection.html
+++ b/Reflection.html
@@ -1122,12 +1122,14 @@ body::after{
   <i class="ri-arrow-up-s-line"></i>
 </button>
 
+<script src="storage.js"></script>
 <script>
 /* ══════════════════════════════════════════════════════════
    CONSTANTS & STATE
 ══════════════════════════════════════════════════════════ */
-const STORAGE_KEY = 'tq_reflection_draft';
-const VAULT_KEY   = 'tq_reflection_vault';
+// Use unified storage keys when available, fall back to legacy keys
+const STORAGE_KEY = window.TaskQuestStorage ? window.TaskQuestStorage.KEYS.REFLECTION_DRAFT : 'tq_reflection_draft';
+const VAULT_KEY   = window.TaskQuestStorage ? window.TaskQuestStorage.KEYS.REFLECTION_VAULT  : 'tq_reflection_vault';
 
 const PROMPTS = [
   { icon:'ri-trophy-line',   pane:'ach', text:'What was my single biggest achievement today?' },

--- a/collaborative.js
+++ b/collaborative.js
@@ -14,9 +14,11 @@ let collaborativeState = {
 // Load collaborative data on init
 function loadCollaborativeData() {
   try {
-    const saved = localStorage.getItem('collab_state');
+    const saved = window.TaskQuestStorage
+      ? window.TaskQuestStorage.getCollab()
+      : JSON.parse(localStorage.getItem('taskquest_v1.collab'));
     if (saved) {
-      collaborativeState = JSON.parse(saved);
+      collaborativeState = saved;
     }
   } catch (e) {
     console.error('Failed to load collaborative data:', e);
@@ -26,7 +28,11 @@ function loadCollaborativeData() {
 // Save collaborative data
 function saveCollaborativeData() {
   try {
-    localStorage.setItem('collab_state', JSON.stringify(collaborativeState));
+    if (window.TaskQuestStorage) {
+      window.TaskQuestStorage.setCollab(collaborativeState);
+    } else {
+      localStorage.setItem('taskquest_v1.collab', JSON.stringify(collaborativeState));
+    }
   } catch (e) {
     console.error('Failed to save collaborative data:', e);
   }

--- a/docs.html
+++ b/docs.html
@@ -76,9 +76,10 @@
     <p>&copy; 2026 Study Task Tracker. Empowering students.</p>
   </footer>
 
+  <script src="storage.js"></script>
   <script>
     const themeSwitcher = document.getElementById("themeSwitcher");
-    const savedTheme = localStorage.getItem("quests_theme") || "cosmic";
+    const savedTheme = (window.TaskQuestStorage ? window.TaskQuestStorage.getTheme() : localStorage.getItem("taskquest_v1.theme")) || "cosmic";
     document.body.setAttribute("data-theme", savedTheme);
     if (savedTheme === "sunset") document.body.classList.add("light");
     themeSwitcher.value = savedTheme;
@@ -87,7 +88,7 @@
       const theme = e.target.value;
       document.body.setAttribute("data-theme", theme);
       if (theme === "sunset") document.body.classList.add("light"); else document.body.classList.remove("light");
-      localStorage.setItem("quests_theme", theme);
+      if (window.TaskQuestStorage) { window.TaskQuestStorage.setTheme(theme); } else { localStorage.setItem("taskquest_v1.theme", theme); }
     });
   </script>
 </body>

--- a/faq.html
+++ b/faq.html
@@ -133,9 +133,10 @@
     <p>&copy; 2026 Study Task Tracker. Simple. Private. Fast.</p>
   </footer>
 
+  <script src="storage.js"></script>
   <script>
     const themeSwitcher = document.getElementById("themeSwitcher");
-    const savedTheme = localStorage.getItem("quests_theme") || "cosmic";
+    const savedTheme = (window.TaskQuestStorage ? window.TaskQuestStorage.getTheme() : localStorage.getItem("taskquest_v1.theme")) || "cosmic";
     document.body.setAttribute("data-theme", savedTheme);
     if (savedTheme === "sunset") document.body.classList.add("light");
     themeSwitcher.value = savedTheme;
@@ -144,7 +145,7 @@
       const theme = e.target.value;
       document.body.setAttribute("data-theme", theme);
       if (theme === "sunset") document.body.classList.add("light"); else document.body.classList.remove("light");
-      localStorage.setItem("quests_theme", theme);
+      if (window.TaskQuestStorage) { window.TaskQuestStorage.setTheme(theme); } else { localStorage.setItem("taskquest_v1.theme", theme); }
     });
 
     // Accordion Logic

--- a/index.html
+++ b/index.html
@@ -2049,29 +2049,77 @@
     <i class="ri-team-line"></i> Open Study Together
   </button>
   <div id="toast-container" class="toast-container" aria-live="polite" aria-atomic="true"></div>
+  <script src="storage.js"></script>
   <script src="script.js"></script>
   <script src="toast.js"></script>
-  <!-- Minimal Timetable Manager -->
-  <section id="timetable-section" class="card" style="margin:16px;">
-    <h2 style="margin:0 0 8px 0;">Timetable</h2>
-    <div class="timetable-form" style="display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin-bottom:12px;">
-      <input id="ttSubjectInput" placeholder="Subject (e.g., Math)" style="flex:1;min-width:160px;padding:8px;border-radius:6px;border:1px solid rgba(255,255,255,0.06);" />
-      <select id="ttDaySelect" style="padding:8px;border-radius:6px;border:1px solid rgba(255,255,255,0.06);">
-        <option value="mon">Mon</option>
-        <option value="tue">Tue</option>
-        <option value="wed">Wed</option>
-        <option value="thu">Thu</option>
-        <option value="fri">Fri</option>
-        <option value="sat">Sat</option>
-        <option value="sun">Sun</option>
-      </select>
-      <input id="ttStartInput" type="time" style="padding:8px;border-radius:6px;border:1px solid rgba(255,255,255,0.06);" />
-      <input id="ttEndInput" type="time" style="padding:8px;border-radius:6px;border:1px solid rgba(255,255,255,0.06);" />
-      <button id="ttAddBtn" class="btn">Add</button>
-    </div>
-    <div id="timetableContainer" class="timetable-grid" aria-live="polite"></div>
-  </section>
   <script src="collaborative.js"></script>
+  <script>
+  /* ── Timetable Manager (single implementation, persisted) ── */
+  (function () {
+    var DAYS_ORDER = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday'];
+
+    function loadEntries() {
+      return window.TaskQuestStorage ? window.TaskQuestStorage.getTimetable() : (JSON.parse(localStorage.getItem('taskquest_v1.timetable')) || []);
+    }
+
+    function saveEntries(entries) {
+      if (window.TaskQuestStorage) { window.TaskQuestStorage.setTimetable(entries); }
+      else { localStorage.setItem('taskquest_v1.timetable', JSON.stringify(entries)); }
+    }
+
+    function render() {
+      var grid = document.getElementById('timetableGrid');
+      if (!grid) return;
+      var entries = loadEntries();
+      if (!entries.length) {
+        grid.innerHTML = '<p style="opacity:.5;padding:16px;">No sessions scheduled yet.</p>';
+        return;
+      }
+      var byDay = {};
+      entries.forEach(function (e) { (byDay[e.day] = byDay[e.day] || []).push(e); });
+      grid.innerHTML = DAYS_ORDER.filter(function (d) { return byDay[d]; }).map(function (day) {
+        var rows = byDay[day].sort(function (a, b) { return a.start.localeCompare(b.start); }).map(function (e) {
+          return '<div class="tt-entry" style="display:flex;align-items:center;gap:10px;padding:6px 10px;border-radius:8px;background:rgba(255,255,255,0.04);margin-bottom:4px;">' +
+            '<span style="font-weight:600;min-width:90px;">' + e.start + ' – ' + e.end + '</span>' +
+            '<span style="flex:1;">' + escTT(e.subject) + '</span>' +
+            '<button onclick="window._ttDelete(' + e.id + ')" style="background:none;border:none;cursor:pointer;color:var(--danger,#ef4444);font-size:16px;" aria-label="Delete">✕</button>' +
+            '</div>';
+        }).join('');
+        return '<div style="margin-bottom:14px;"><h4 style="margin:0 0 6px 0;font-size:13px;opacity:.7;">' + day + '</h4>' + rows + '</div>';
+      }).join('');
+    }
+
+    function escTT(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+
+    window._ttDelete = function (id) {
+      var entries = loadEntries().filter(function (e) { return e.id !== id; });
+      saveEntries(entries);
+      render();
+    };
+
+    function addEntry() {
+      var day     = (document.getElementById('ttDayInput') || {}).value;
+      var subject = (document.getElementById('ttSubjectInput') || {}).value.trim();
+      var start   = (document.getElementById('ttStartTimeInput') || {}).value;
+      var end     = (document.getElementById('ttEndTimeInput') || {}).value;
+      if (!day || !subject || !start || !end) { alert('Please fill in all timetable fields.'); return; }
+      if (start >= end) { alert('End time must be after start time.'); return; }
+      var entries = loadEntries();
+      entries.push({ id: Date.now(), day: day, subject: subject, start: start, end: end });
+      saveEntries(entries);
+      document.getElementById('ttSubjectInput').value = '';
+      document.getElementById('ttStartTimeInput').value = '';
+      document.getElementById('ttEndTimeInput').value = '';
+      render();
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+      var btn = document.getElementById('addTimetableBtn');
+      if (btn) btn.addEventListener('click', addEntry);
+      render();
+    });
+  })();
+  </script>
 
   <button class="back-to-top-btn" id="backToTopBtn" aria-label="Back to top">
     <i class="ri-arrow-up-line"></i>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -248,6 +248,7 @@
     </section>
   </main>
 
+  <script src="storage.js"></script>
   <script src="leaderboard.js"></script>
 </body>
 </html>

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,10 +1,12 @@
 (function() {
-  const STORAGE_KEY = "taskquest_leaderboard_v1";
-  const PROFILE_KEY = "quests_profile";
-  const COINS_KEY = "coins";
-  const TASKS_KEY = "quests";
-  const STREAK_KEY = "streak";
-  const XP_KEY = "xp";
+  // Use unified storage keys when available, fall back to legacy keys
+  const _S = window.TaskQuestStorage;
+  const STORAGE_KEY = _S ? _S.KEYS.LEADERBOARD    : "taskquest_leaderboard_v1";
+  const PROFILE_KEY = _S ? _S.KEYS.PROFILE         : "quests_profile";
+  const COINS_KEY   = _S ? _S.KEYS.COINS            : "coins";
+  const TASKS_KEY   = _S ? _S.KEYS.TASKS            : "quests";
+  const STREAK_KEY  = _S ? _S.KEYS.STREAK           : "streak";
+  const XP_KEY      = _S ? _S.KEYS.XP               : "xp";
   const REFRESH_INTERVAL = 900;
   const currentTimestamp = () => new Date().toISOString();
 

--- a/script.js
+++ b/script.js
@@ -1,5 +1,7 @@
 // --- State Management ---
-let tasks = JSON.parse(localStorage.getItem("tasks")) || [];
+// Migrate any legacy keys to the unified taskquest_v1 namespace on first load
+if (window.TaskQuestStorage) { window.TaskQuestStorage.migrate(); }
+let tasks = (window.TaskQuestStorage ? window.TaskQuestStorage.getTasks() : JSON.parse(localStorage.getItem("tasks"))) || [];
 
 // --- Selectors ---
 const taskForm = document.getElementById("taskForm");
@@ -73,7 +75,11 @@ function editTask(id) {
 }
 
 function saveAndRender() {
-  localStorage.setItem("tasks", JSON.stringify(tasks));
+  if (window.TaskQuestStorage) {
+    window.TaskQuestStorage.setTasks(tasks);
+  } else {
+    localStorage.setItem("taskquest_v1.tasks", JSON.stringify(tasks));
+  }
   renderTasks();
 }
 
@@ -124,7 +130,7 @@ function updateStats() {
 // --- Theme Management ---
 
 function initTheme() {
-  const savedTheme = localStorage.getItem("theme") || "light";
+  const savedTheme = (window.TaskQuestStorage ? window.TaskQuestStorage.getTheme() : localStorage.getItem("taskquest_v1.theme")) || "cosmic";
   document.documentElement.setAttribute("data-theme", savedTheme);
 
   if (themeSwitcher) {
@@ -132,7 +138,11 @@ function initTheme() {
     themeSwitcher.addEventListener("change", (e) => {
       const selectedTheme = e.target.value;
       document.documentElement.setAttribute("data-theme", selectedTheme);
-      localStorage.setItem("theme", selectedTheme);
+      if (window.TaskQuestStorage) {
+        window.TaskQuestStorage.setTheme(selectedTheme);
+      } else {
+        localStorage.setItem("taskquest_v1.theme", selectedTheme);
+      }
     });
   }
 }

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,191 @@
+/**
+ * storage.js — Unified versioned localStorage contract for TaskQuest
+ *
+ * All pages MUST use these constants and helpers instead of raw
+ * localStorage calls with ad-hoc key strings.
+ *
+ * Schema version: taskquest_v1
+ *
+ * Key registry
+ * ─────────────────────────────────────────────────────────────────
+ * taskquest_v1.tasks          – main task array (was "tasks" / "quests")
+ * taskquest_v1.theme          – active theme string  (was "theme" / "quests_theme")
+ * taskquest_v1.profile        – user profile object  (was "quests_profile")
+ * taskquest_v1.coins          – integer              (was "coins")
+ * taskquest_v1.streak         – integer              (was "streak")
+ * taskquest_v1.xp             – integer              (was "xp")
+ * taskquest_v1.leaderboard    – leaderboard entries  (was "taskquest_leaderboard_v1")
+ * taskquest_v1.collab         – collaborative state  (was "collab_state")
+ * taskquest_v1.reflection_draft – reflection draft   (was "tq_reflection_draft")
+ * taskquest_v1.reflection_vault – reflection vault   (was "tq_reflection_vault")
+ * taskquest_v1.challenge      – challenge state      (was in-memory only)
+ * taskquest_v1.timetable      – timetable entries    (was split / missing)
+ * ─────────────────────────────────────────────────────────────────
+ */
+
+(function (global) {
+  "use strict";
+
+  // ── Namespace prefix ──────────────────────────────────────────────────────
+  const NS = "taskquest_v1.";
+
+  // ── Public key constants ──────────────────────────────────────────────────
+  const KEYS = {
+    TASKS:             NS + "tasks",
+    THEME:             NS + "theme",
+    PROFILE:           NS + "profile",
+    COINS:             NS + "coins",
+    STREAK:            NS + "streak",
+    XP:                NS + "xp",
+    LEADERBOARD:       NS + "leaderboard",
+    COLLAB:            NS + "collab",
+    REFLECTION_DRAFT:  NS + "reflection_draft",
+    REFLECTION_VAULT:  NS + "reflection_vault",
+    CHALLENGE:         NS + "challenge",
+    TIMETABLE:         NS + "timetable",
+  };
+
+  // ── Legacy key → canonical key migration map ──────────────────────────────
+  const LEGACY_MAP = {
+    // old key              : canonical KEYS property
+    "tasks":                  KEYS.TASKS,
+    "quests":                 KEYS.TASKS,
+    "theme":                  KEYS.THEME,
+    "quests_theme":           KEYS.THEME,
+    "quests_profile":         KEYS.PROFILE,
+    "coins":                  KEYS.COINS,
+    "streak":                 KEYS.STREAK,
+    "xp":                     KEYS.XP,
+    "taskquest_leaderboard_v1": KEYS.LEADERBOARD,
+    "collab_state":           KEYS.COLLAB,
+    "tq_reflection_draft":    KEYS.REFLECTION_DRAFT,
+    "tq_reflection_vault":    KEYS.REFLECTION_VAULT,
+  };
+
+  // ── Core helpers ──────────────────────────────────────────────────────────
+
+  function get(key, fallback) {
+    try {
+      const raw = localStorage.getItem(key);
+      if (raw === null) return fallback !== undefined ? fallback : null;
+      return JSON.parse(raw);
+    } catch (e) {
+      return fallback !== undefined ? fallback : null;
+    }
+  }
+
+  function set(key, value) {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+      return true;
+    } catch (e) {
+      console.warn("[TaskQuest Storage] Failed to write key:", key, e);
+      return false;
+    }
+  }
+
+  function remove(key) {
+    try { localStorage.removeItem(key); } catch (e) { /* ignore */ }
+  }
+
+  // ── Migration ─────────────────────────────────────────────────────────────
+  /**
+   * Runs once on page load.
+   * Copies any data stored under legacy keys into the canonical keys,
+   * then removes the legacy keys so they no longer pollute storage.
+   */
+  function migrate() {
+    let migrated = false;
+
+    Object.entries(LEGACY_MAP).forEach(function (entry) {
+      const legacyKey = entry[0];
+      const canonicalKey = entry[1];
+
+      const legacyRaw = localStorage.getItem(legacyKey);
+      if (legacyRaw === null) return; // nothing to migrate
+
+      // Only migrate if the canonical slot is still empty
+      if (localStorage.getItem(canonicalKey) === null) {
+        try {
+          localStorage.setItem(canonicalKey, legacyRaw);
+          migrated = true;
+        } catch (e) {
+          console.warn("[TaskQuest Storage] Migration write failed:", canonicalKey, e);
+        }
+      }
+
+      // Remove the legacy key regardless (canonical slot wins)
+      try { localStorage.removeItem(legacyKey); } catch (e) { /* ignore */ }
+    });
+
+    if (migrated) {
+      console.info("[TaskQuest Storage] Legacy keys migrated to taskquest_v1 namespace.");
+    }
+  }
+
+  // ── Typed accessors ───────────────────────────────────────────────────────
+
+  const Storage = {
+    KEYS: KEYS,
+
+    // Generic
+    get: get,
+    set: set,
+    remove: remove,
+
+    // Tasks
+    getTasks:   function () { return get(KEYS.TASKS, []); },
+    setTasks:   function (v) { return set(KEYS.TASKS, v); },
+
+    // Theme
+    getTheme:   function () { return get(KEYS.THEME, "cosmic"); },
+    setTheme:   function (v) { return set(KEYS.THEME, v); },
+
+    // Profile
+    getProfile: function () { return get(KEYS.PROFILE, null); },
+    setProfile: function (v) { return set(KEYS.PROFILE, v); },
+
+    // Coins
+    getCoins:   function () { return get(KEYS.COINS, 0); },
+    setCoins:   function (v) { return set(KEYS.COINS, v); },
+
+    // Streak
+    getStreak:  function () { return get(KEYS.STREAK, 0); },
+    setStreak:  function (v) { return set(KEYS.STREAK, v); },
+
+    // XP
+    getXP:      function () { return get(KEYS.XP, 0); },
+    setXP:      function (v) { return set(KEYS.XP, v); },
+
+    // Leaderboard
+    getLeaderboard: function () { return get(KEYS.LEADERBOARD, null); },
+    setLeaderboard: function (v) { return set(KEYS.LEADERBOARD, v); },
+
+    // Collaborative state
+    getCollab:  function () { return get(KEYS.COLLAB, null); },
+    setCollab:  function (v) { return set(KEYS.COLLAB, v); },
+
+    // Reflection draft
+    getReflectionDraft: function () { return get(KEYS.REFLECTION_DRAFT, null); },
+    setReflectionDraft: function (v) { return set(KEYS.REFLECTION_DRAFT, v); },
+
+    // Reflection vault
+    getReflectionVault: function () { return get(KEYS.REFLECTION_VAULT, []); },
+    setReflectionVault: function (v) { return set(KEYS.REFLECTION_VAULT, v); },
+
+    // Challenge state
+    getChallenge: function () { return get(KEYS.CHALLENGE, null); },
+    setChallenge: function (v) { return set(KEYS.CHALLENGE, v); },
+
+    // Timetable
+    getTimetable: function () { return get(KEYS.TIMETABLE, []); },
+    setTimetable: function (v) { return set(KEYS.TIMETABLE, v); },
+
+    // Run migration (call once at app boot)
+    migrate: migrate,
+  };
+
+  // ── Expose globally ───────────────────────────────────────────────────────
+  global.TaskQuestStorage = Storage;
+
+})(window);


### PR DESCRIPTION
- Add storage.js: single source of truth for all localStorage keys under the taskquest_v1.* namespace with typed accessors and automatic migration from all legacy keys

- Migrate legacy keys:
    tasks / quests          -> taskquest_v1.tasks
    theme / quests_theme    -> taskquest_v1.theme
    quests_profile          -> taskquest_v1.profile
    coins                   -> taskquest_v1.coins
    streak                  -> taskquest_v1.streak
    xp                      -> taskquest_v1.xp
    taskquest_leaderboard_v1 -> taskquest_v1.leaderboard
    collab_state            -> taskquest_v1.collab
    tq_reflection_draft     -> taskquest_v1.reflection_draft
    tq_reflection_vault     -> taskquest_v1.reflection_vault

- script.js: use TaskQuestStorage for tasks and theme; align theme default to 'cosmic' (was 'light') to match rest of app

- leaderboard.js: resolve all key constants through TaskQuestStorage so leaderboard syncs correctly with dashboard data

- collaborative.js: persist collab_state via TaskQuestStorage

- Challenge.js: add full persistence (saveState/loadState) so challenge progress survives page reloads

- Reflection.html: use unified STORAGE_KEY / VAULT_KEY constants via TaskQuestStorage

- faq.html / docs.html: read and write theme via TaskQuestStorage

- index.html: load storage.js before all other scripts; remove duplicate timetable section (timetableContainer/#ttAddBtn) and replace with single persisted implementation wired to the existing timetable tab (#timetableGrid/#addTimetableBtn)

- leaderboard.html: load storage.js before leaderboard.js

Closes #358