### PR TITLE
a11y: add semantic main tag to focus.html

### DIFF
--- a/focus.html
+++ b/focus.html
@@ -103,6 +103,7 @@ input[type=range].vol{width:72px;accent-color:var(--accent)}
 </style>
 </head>
 <body>
+<main>
 
 <div class="hub">
 


### PR DESCRIPTION
# Related Issue
Closes #380 

# Summary
Ensures WCAG compliance by adding the required `<main>` landmark element to `focus.html`.

# Changes Made
* [x] Added `<main>` element.

# Testing
* Audited page structure via Lighthouse.

# Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
