### PR TITLE
a11y: add semantic main tag to leaderboard.html

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -14,6 +14,7 @@
 </head>
 
 <body>
+<main>
   <div class="bg blur1" aria-hidden="true"></div>
   <div class="bg blur2" aria-hidden="true"></div>
   <div class="grid-overlay" aria-hidden="true"></div>


### PR DESCRIPTION
# Related Issue
Closes #384 

# Summary
Enhances screen reader compatibility and page hierarchy on the Leaderboard page by introducing the `<main>` HTML5 landmark.

# Changes Made
* [x] Added semantic `<main>` tag at the start of the body content.

# Testing
* Ensured no visual disruptions occurred due to the new block element.

# Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
