### PR TITLE
style: add focus states to Games.css

### DIFF
--- a/Games.css
+++ b/Games.css
@@ -54,7 +54,7 @@ body{background:var(--bg);color:var(--txt);font-family:-apple-system,BlinkMacSys
 .game-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px}
 
 .game-card{background:var(--bg-card);border:0.5px solid var(--bdr);border-radius:var(--rl);padding:18px;display:flex;flex-direction:column;gap:10px;transition:border-color .2s,transform .2s;cursor:default}
-.game-card:hover{border-color:var(--bdr2);transform:translateY(-2px)}
+.game-card:hover, .game-card:focus-within {border-color:var(--bdr2);transform:translateY(-2px)}
 
 .gc-header{display:flex;align-items:center;justify-content:space-between}
 .gc-icon{width:40px;height:40px;border-radius:var(--r);display:flex;align-items:center;justify-content:center;font-size:20px}


### PR DESCRIPTION
# Related Issue
Closes #398 

# Summary
Ensures interactive game cards remain accessible when navigating via keyboard by applying `:hover` interaction styles to `:focus-within` states.

# Changes Made
* [x] Grouped `.game-card:hover` with `.game-card:focus-within` in `Games.css`.

# Testing
* Tabbed into game cards and verified visual depth pop-out occurs identically to mouse hover.

# Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
