### PR TITLE
style: add :focus-visible for better keyboard accessibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -4056,6 +4056,10 @@ body.light .modal-progress-bar {
   transition: var(--transition);
 }
 
+.view-btn:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
 .view-btn:hover {
   background: rgba(255, 255, 255, 0.08);
   color: var(--text);


### PR DESCRIPTION
# Related Issue
Closes #400 

# Summary
Enhances keyboard navigation for power users and users with disabilities by adding standard `:focus-visible` outlines to buttons in `style.css`.

# Changes Made
* [x] Added `:focus-visible` pseudo-class styling for buttons.
* [x] Configured visible 2px solid primary-colored outline.

# Testing
* Used the "Tab" key to navigate through the interface; confirmed focus ring is highly visible.

# Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No unrelated changes included
