### PR TITLE
feat: persist focus game scores and streaks using unified storage manager

### DIFF
--- a/Games.js
+++ b/Games.js
@@ -1,12 +1,23 @@
 /* ===== GLOBAL STATE ===== */
-let globalScore = 0;
-let globalStreak = 0;
+const _S = window.TaskQuestStorage;
+let globalScore = _S ? _S.getCoins() : 0;
+let globalStreak = _S ? _S.getStreak() : 0;
+
 function addScore(n){
   globalScore += n;
   globalStreak++;
   document.getElementById('global-score').textContent = globalScore;
   document.getElementById('global-streak').textContent = globalStreak;
+  if (_S) {
+    _S.setCoins(globalScore);
+    _S.setStreak(globalStreak);
+  }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('global-score').textContent = globalScore;
+  document.getElementById('global-streak').textContent = globalStreak;
+});
 function openGame(id){
   document.getElementById('overlay-'+id).classList.remove('hidden');
   document.body.style.overflow='hidden';


### PR DESCRIPTION
# Related Issue
Closes #418 

# Summary
Connects game variables to unified storage, preserving states across refreshes.

# Changes Made
- Integrated `TaskQuestStorage` getters for loading initial score/streak details.
- Updated `addScore()` to write updated totals to localStorage using unified keys.
- Added `DOMContentLoaded` wrapper setting matching text values.

# Testing
Played multiple mini-games, verified score increases, and confirmed stats remained after page refresh.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
