### PR TITLE
feat: add smooth scroll-progress reading bar to Terms page

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -31,9 +31,20 @@
       color: var(--text-muted, #94a3b8);
       line-height: 1.6;
     }
+    #scrollProgress {
+      position: fixed;
+      top: 0;
+      left: 0;
+      height: 4px;
+      background: linear-gradient(to right, var(--primary), var(--secondary));
+      width: 0%;
+      z-index: 10000;
+      transition: width 0.1s ease-out;
+    }
   </style>
 </head>
 <body class="legal-page">
+  <div id="scrollProgress"></div>
 <main>
 
   <!-- BACKGROUND -->
@@ -87,5 +98,13 @@
     <p>&copy; 2026 TaskQuest. Level Up Productivity.</p>
   </footer>
 
+  <script>
+    window.addEventListener("scroll", () => {
+      const winScroll = document.body.scrollTop || document.documentElement.scrollTop;
+      const height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+      const scrolled = height > 0 ? (winScroll / height) * 100 : 0;
+      document.getElementById("scrollProgress").style.width = scrolled + "%";
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
# Related Issue
Closes #426 
# Summary
Adds a fixed visual indicator showing scroll depth progress on the Terms page.

# Changes Made
- Injected CSS progress element container styled with primary-to-secondary gradients.
- Added a scroll event listener updating the element's width percentage matching document height.

# Testing
Verified scroll tracking behaves correctly on desktop and mobile browsers.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
