### PR TITLE
feat: add local data inspection and reset utility to privacy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -44,7 +44,20 @@
         <p class="header-subtitle">
           <span id="headerGreeting">👋 Focus Time!</span>
         </p>
-      </div>
+        <section style="margin-top: 2rem; border-top: 1px solid var(--border); padding-top: 2rem;">
+        <h2><i class="ri-delete-bin-line"></i> 5. Manage Your Data</h2>
+        <p>TaskQuest data resides strictly on your browser. You can inspect the storage size or reset the application data below.</p>
+        <div class="data-manager-card" style="background: rgba(255, 255, 255, 0.02); border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem; margin-top: 1rem; display: flex; flex-direction: column; gap: 1rem;">
+          <div style="display: flex; justify-content: space-between; align-items: center;">
+            <span>Estimated storage usage:</span>
+            <strong id="storageSize">Calculating...</strong>
+          </div>
+          <button id="clearDataBtn" style="background: #ef4444; color: #fff; border: none; padding: 10px 16px; border-radius: 8px; cursor: pointer; font-weight: 600; align-self: flex-start; transition: background 0.2s;">
+            <i class="ri-alert-line"></i> Reset All Application Data
+          </button>
+        </div>
+      </section>
+    </div>
       <div class="header-controls">
         <div class="stats-pill">
           <span class="stats-pill-label">Status</span>
@@ -82,5 +95,26 @@
     <p>&copy; 2026 TaskQuest. Level Up Productivity.</p>
   </footer>
 
+  <script>
+    function updateStorageSize() {
+      let total = 0;
+      for (let x in localStorage) {
+        if (localStorage.hasOwnProperty(x)) {
+          total += (localStorage[x].length + x.length) * 2;
+        }
+      }
+      const kb = (total / 1024).toFixed(2);
+      document.getElementById("storageSize").textContent = kb + " KB";
+    }
+    updateStorageSize();
+
+    document.getElementById("clearDataBtn").addEventListener("click", () => {
+      if (confirm("Are you absolutely sure you want to delete all your tasks, coins, XP, and stats? This cannot be undone.")) {
+        localStorage.clear();
+        alert("All application data has been successfully reset.");
+        window.location.href = "index.html";
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
# Related Issue
Closes #428 

# Summary
Adds a data management card to the privacy policy page to let users view storage space size and clear application states.

# Changes Made
- Added a responsive UI section titled "Manage Your Data".
- Created calculations using the sizes of keys & values stored under the local namespace.
- Added a button with verification confirm dialog to wipe local state and redirect to home.

# Testing
Checked the calculations with varying task list sizes and confirmed correct KB sizes and total reset completion.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
