### PR TITLE
fix: improve FAQ accordion mobile responsiveness and keyboard accessi…

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -34,12 +34,11 @@
     .faq-answer {
       max-height: 0;
       overflow: hidden;
-      transition: max-height 0.3s ease-out;
+      transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1), padding 0.3s ease;
       color: var(--text-muted);
       padding-right: 2rem;
     }
     .faq-item.active .faq-answer {
-      max-height: 200px;
       padding-top: 1rem;
     }
     .faq-icon {
@@ -89,41 +88,41 @@
   <main class="container">
     <div class="faq-accordion">
       <div class="faq-item">
-        <button class="faq-question">
+        <button class="faq-question" aria-expanded="false" aria-controls="faq-ans-2">
           <span>How is my data saved?</span>
           <span class="faq-icon">▼</span>
         </button>
-        <div class="faq-answer">
+        <div class="faq-answer" id="faq-ans-2" role="region">
           <p>We use your browser's Local Storage to save tasks. This means your data stays on your machine and is never uploaded to any server.</p>
         </div>
       </div>
 
       <div class="faq-item">
-        <button class="faq-question">
+        <button class="faq-question" aria-expanded="false" aria-controls="faq-ans-3">
           <span>Will I lose my tasks if I close the tab?</span>
           <span class="faq-icon">▼</span>
         </button>
-        <div class="faq-answer">
+        <div class="faq-answer" id="faq-ans-3" role="region">
           <p>No! Local Storage persists even after you close the browser or restart your computer. However, clearing browser history/cache might delete them.</p>
         </div>
       </div>
 
       <div class="faq-item">
-        <button class="faq-question">
+        <button class="faq-question" aria-expanded="false" aria-controls="faq-ans-4">
           <span>Is there a mobile app?</span>
           <span class="faq-icon">▼</span>
         </button>
-        <div class="faq-answer">
+        <div class="faq-answer" id="faq-ans-4" role="region">
           <p>This is a web-based tool, but it is fully responsive and works perfectly on mobile browsers. You can even "Add to Home Screen" for an app-like experience.</p>
         </div>
       </div>
 
       <div class="faq-item">
-        <button class="faq-question">
+        <button class="faq-question" aria-expanded="false" aria-controls="faq-ans-1">
           <span>Can I sync my tasks across devices?</span>
           <span class="faq-icon">▼</span>
         </button>
-        <div class="faq-answer">
+        <div class="faq-answer" id="faq-ans-1" role="region">
           <p>Currently, no. Since we value privacy and don't require accounts, tasks are specific to the device and browser where they were created.</p>
         </div>
       </div>
@@ -149,11 +148,21 @@
       if (window.TaskQuestStorage) { window.TaskQuestStorage.setTheme(theme); } else { localStorage.setItem("taskquest_v1.theme", theme); }
     });
 
-    // Accordion Logic
+    // Accordion Logic with ScrollHeight and ARIA updates
     document.querySelectorAll('.faq-question').forEach(button => {
       button.addEventListener('click', () => {
         const item = button.parentElement;
+        const answer = button.nextElementSibling;
+        const isExpanded = button.getAttribute('aria-expanded') === 'true';
+        
         item.classList.toggle('active');
+        button.setAttribute('aria-expanded', !isExpanded);
+        
+        if (!isExpanded) {
+          answer.style.maxHeight = answer.scrollHeight + "px";
+        } else {
+          answer.style.maxHeight = "0";
+        }
       });
     });
   </script>


### PR DESCRIPTION
# Related Issue
Closes #430 

# Summary
Fixes height truncation on mobile viewports for FAQ accordions and brings them into accessibility compliance.

# Changes Made
- Replaced static `max-height: 200px` transition with dynamic CSS height handling.
- Added `aria-expanded="false"`, `aria-controls="..."` to buttons, and `role="region"` to panel contents.
- Modernized the click logic to calculate and set height using `scrollHeight` when opened.

# Testing
Checked on multiple simulated screen sizes down to 320px width; long paragraphs fit perfectly.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
