### PR TITLE
fix: persist and render already-earned badges in achievements bar on boot

### DIFF
--- a/Challenge.js
+++ b/Challenge.js
@@ -60,6 +60,21 @@ function loadState() {
     if (saved && typeof saved === "object") {
       state = Object.assign(state, saved);
     }
+    // Populate badges on load
+    if (state.earnedBadges && state.earnedBadges.length > 0) {
+      setTimeout(() => {
+        const bar = document.getElementById("ach-badges");
+        if (bar) {
+          bar.innerHTML = "";
+          state.earnedBadges.forEach(label => {
+            const el = document.createElement("span");
+            el.className = "badge-item";
+            el.textContent = label;
+            bar.appendChild(el);
+          });
+        }
+      }, 50);
+    }
   } catch (e) { /* corrupt data — use defaults */ }
 }
 


### PR DESCRIPTION
# Related Issue
Closes #434 

# Summary
Fixes a bug where earned badges vanished from the UI achievements shelf when the browser refreshed.

# Changes Made
- Added rendering loops inside `loadState()` executing visual additions on page load.
- Ensured elements are safe-checks and avoid empty-state text overlaps.

# Testing
Earned 3 badges, refreshed the tab, and verified they all displayed.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
