### PR TITLE
a11y: add skip-to-main-content landmark and links in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
 </head>
 
 <body>
+  <a href="#quests-tab" class="skip-to-content" style="position: absolute; top: -100px; left: 10px; background: var(--primary); color: #fff; padding: 8px 16px; border-radius: 4px; z-index: 10000; transition: top 0.2s;" onfocus="this.style.top='10px'" onblur="this.style.top='-100px'">Skip to content</a>
 
   <!-- GLOBAL HEADER -->
   <header class="site-header" style="position: sticky; top: 0; z-index: 1000; padding: 12px 0; border-bottom: 1px solid var(--border); background: rgba(15, 12, 38, 0.6); backdrop-filter: blur(15px);">


### PR DESCRIPTION
# Related Issue
Closes #436 

# Summary
Adds a skip-to-content hyperlink to jump past header menus using the keyboard.

# Changes Made
- Injected styled skip-to-content anchor tag directly inside the `<body>` element.
- Linked skip actions target the main `#quests-tab` viewport focus.

# Testing
Used keyboard navigation (`Tab` key) and verified focus skip jumps past the header links.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
