### PR TITLE
fix(analytics): migrate Analytics Hub to canonical `taskquest_v1` storage API

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -4,9 +4,9 @@
 (function () {
   "use strict";
 
-  const QUESTS_KEY = "quests";
-  const TASKS_KEY = "tasks";
-  const STREAK_KEY = "streak";
+  // Storage keys — read from the canonical taskquest_v1 namespace via
+  // window.TaskQuestStorage (storage.js). The legacy "quests" / "tasks" /
+  // "streak" constants are intentionally removed; use the API accessors below.
   const HEATMAP_WEEKS = 15;
   const CATEGORIES = ["Theory", "Practical", "Assignment", "Revision", "General"];
 
@@ -54,24 +54,14 @@
   function loadQuests() {
     let list = [];
     try {
-      const questsRaw = localStorage.getItem(QUESTS_KEY);
-      if (questsRaw) {
-        const parsed = JSON.parse(questsRaw);
-        if (Array.isArray(parsed)) list = parsed;
+      // Use the unified storage API so we always read from the canonical
+      // taskquest_v1.tasks key regardless of any legacy migration state.
+      if (window.TaskQuestStorage && typeof window.TaskQuestStorage.getTasks === "function") {
+        const stored = window.TaskQuestStorage.getTasks();
+        if (Array.isArray(stored)) list = stored;
       }
     } catch (e) {
       list = [];
-    }
-    if (list.length === 0) {
-      try {
-        const tasksRaw = localStorage.getItem(TASKS_KEY);
-        if (tasksRaw) {
-          const parsed = JSON.parse(tasksRaw);
-          if (Array.isArray(parsed)) list = parsed;
-        }
-      } catch (e) {
-        list = [];
-      }
     }
     return list.map(normalizeQuest);
   }
@@ -103,7 +93,12 @@
   }
 
   function calcStreak(quests) {
-    const stored = parseInt(localStorage.getItem(STREAK_KEY), 10);
+    // Read streak from the canonical storage API instead of the legacy "streak" key.
+    const storedStreak =
+      window.TaskQuestStorage && typeof window.TaskQuestStorage.getStreak === "function"
+        ? window.TaskQuestStorage.getStreak()
+        : 0;
+    const stored = parseInt(storedStreak, 10);
     if (!Number.isNaN(stored) && stored > 0) return stored;
     const days = new Set(
       quests
@@ -620,7 +615,13 @@
       el.addEventListener("click", () => setTimeout(refreshAnalytics, 50));
     });
     window.addEventListener("storage", (e) => {
-      if (e.key === QUESTS_KEY || e.key === TASKS_KEY || e.key === STREAK_KEY) refreshAnalytics();
+      // Listen for changes on the canonical versioned keys produced by storage.js.
+      if (
+        e.key === "taskquest_v1.tasks" ||
+        e.key === "taskquest_v1.streak"
+      ) {
+        refreshAnalytics();
+      }
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -2074,6 +2074,7 @@
   </button>
   <div id="toast-container" class="toast-container" aria-live="polite" aria-atomic="true"></div>
   <script src="storage.js"></script>
+  <script src="analytics.js"></script>
   <script src="prioritization.js"></script>
   <script src="script.js"></script>
   <script src="toast.js"></script>


### PR DESCRIPTION
# fix(analytics): migrate Analytics Hub to canonical `taskquest_v1` storage API

Closes #375

## Summary

The Analytics Hub was reading task and streak data from hardcoded legacy
`localStorage` keys (`"quests"`, `"tasks"`, `"streak"`) that no longer exist
after the `storage.js` migration. For any new user whose data lives exclusively
under the `taskquest_v1.*` namespace, all charts, the heatmap, and every stat
card rendered as zero / empty.

This PR fixes all three call-sites and adds the missing `<script>` tag that
prevented the module from loading at all.

---

## Changes

### `analytics.js`

| What changed | Before | After |
|---|---|---|
| Legacy key constants | `QUESTS_KEY = "quests"`, `TASKS_KEY = "tasks"`, `STREAK_KEY = "streak"` | Removed; replaced with an explanatory comment |
| `loadQuests()` | `localStorage.getItem("quests")` → fallback `localStorage.getItem("tasks")` | `window.TaskQuestStorage.getTasks()` |
| `calcStreak()` | `localStorage.getItem("streak")` | `window.TaskQuestStorage.getStreak()` |
| `storage` event listener in `initTabRefresh()` | Watched legacy keys `"quests"`, `"tasks"`, `"streak"` | Watches canonical keys `"taskquest_v1.tasks"`, `"taskquest_v1.streak"` |

### `index.html`

- **Added the missing `<script src="analytics.js">` tag** immediately after
  `<script src="storage.js">`, ensuring `window.TaskQuestStorage` is defined
  before analytics code runs.

> [!NOTE]
> `analytics.js` was completely absent from `index.html`, meaning the Analytics
> Hub was silently broken even before the storage-key mismatch. Both issues are
> fixed in this PR.

---

## How to Test

1. Open the app in a fresh browser profile (or run `localStorage.clear()` in DevTools).
2. Add several tasks via the main Quests workspace — data is written to `taskquest_v1.tasks`.
3. Complete some tasks.
4. Navigate to the **Analytics Hub** tab.
5. ✅ Charts, heatmap, stat cards, and streak counter should all reflect real data.

### Before this fix
All analytics panels showed `0` / empty state for any new user.

### After this fix
All panels correctly read from `window.TaskQuestStorage.getTasks()` /
`window.TaskQuestStorage.getStreak()`.

---

## Files Changed

- [`analytics.js`](../../analytics.js) — 4 call-sites updated
- [`index.html`](../../index.html) — 1 `<script>` tag added

---

## Related

- References `storage.js` key registry (lines 18–30) and the `TaskQuestStorage`
  typed accessors (`getTasks`, `getStreak`).
- No schema changes. No new dependencies. Fully backward-compatible.
