### PR TITLE
fix(focus): resolve AudioContext memory leak in ambient audio player

### DIFF
--- a/focus.html
+++ b/focus.html
@@ -408,6 +408,11 @@ function stopAudio() {
   oscillators.forEach(({osc,lfo})=>{try{osc.stop();}catch(e){}try{if(lfo)lfo.stop();}catch(e){}});
   oscillators=[];
   if(gainNode){try{gainNode.disconnect();}catch(e){}gainNode=null;}
+  // Suspend the AudioContext to release the audio hardware thread and
+  // stop background processing — fixes the memory/battery leak (#377).
+  if(audioCtx && audioCtx.state==='running'){
+    audioCtx.suspend().catch(e=>console.warn('AudioContext suspend failed:',e));
+  }
 }
 
 function togglePlay() {
@@ -570,6 +575,22 @@ function rotateQuote() {
   },500);
 }
 setInterval(rotateQuote,8000);
+
+// Suspend/resume audio when the tab is hidden/shown to save battery (#377).
+document.addEventListener('visibilitychange',()=>{
+  if(!audioCtx) return;
+  if(document.hidden){
+    if(audioCtx.state==='running') audioCtx.suspend().catch(()=>{});
+  } else {
+    if(isPlaying && audioCtx.state==='suspended') audioCtx.resume().catch(()=>{});
+  }
+});
+
+// Close the AudioContext entirely when the page is unloaded to prevent
+// zombie contexts from persisting in the browser's audio engine (#377).
+window.addEventListener('beforeunload',()=>{
+  if(audioCtx) audioCtx.close().catch(()=>{});
+});
 
 window.addEventListener('load',()=>{
   drawAmbient();


### PR DESCRIPTION
# fix(focus): resolve AudioContext memory leak in ambient audio player

**Closes #377**

---

## Summary

The FocusZone ambient audio player was leaking `AudioContext` resources every time the user paused audio or left the page. The audio processing thread continued running in the background despite no sound being produced, causing steadily increasing memory usage and unnecessary battery drain — especially on mobile.

---

## Problem

`stopAudio()` stopped and disconnected all oscillator nodes, but never suspended or closed the underlying `AudioContext`. This meant:

- `audioCtx.state` remained `"running"` after pausing
- The browser's audio hardware thread stayed alive indefinitely
- Toggling Play/Pause 20+ times caused measurable memory growth
- Mobile devices experienced continuous battery drain from the audio engine

---

## Solution

Three targeted changes to [`focus.html`](focus.html):

### 1. Suspend on stop (`stopAudio`)
After tearing down oscillator nodes, `audioCtx.suspend()` is now called. This halts the audio processing thread and releases hardware resources, while keeping the context object alive for cheap reuse on the next play.

```js
// Before
function stopAudio() {
  oscillators.forEach(({ osc, lfo }) => { osc.stop(); if (lfo) lfo.stop(); });
  oscillators = [];
  if (gainNode) { gainNode.disconnect(); gainNode = null; }
  // ❌ AudioContext left in 'running' state — thread stays alive
}

// After
function stopAudio() {
  oscillators.forEach(({ osc, lfo }) => { osc.stop(); if (lfo) lfo.stop(); });
  oscillators = [];
  if (gainNode) { gainNode.disconnect(); gainNode = null; }
  // ✅ Suspend halts the audio thread, freeing hardware resources
  if (audioCtx && audioCtx.state === 'running') {
    audioCtx.suspend().catch(e => console.warn('AudioContext suspend failed:', e));
  }
}
```

### 2. Auto-suspend on tab hide (`visibilitychange`)
When the user switches tabs or minimizes the window, the audio context is automatically suspended. It resumes when the tab becomes visible again — but only if audio was already playing.

```js
document.addEventListener('visibilitychange', () => {
  if (!audioCtx) return;
  if (document.hidden) {
    if (audioCtx.state === 'running') audioCtx.suspend().catch(() => {});
  } else {
    if (isPlaying && audioCtx.state === 'suspended') audioCtx.resume().catch(() => {});
  }
});
```

### 3. Full close on page unload (`beforeunload`)
When the user navigates away, the `AudioContext` is fully closed and destroyed, preventing zombie audio threads from persisting in the browser's audio engine across navigations.

```js
window.addEventListener('beforeunload', () => {
  if (audioCtx) audioCtx.close().catch(() => {});
});
```

---

## Files Changed

| File | Change |
|---|---|
| `focus.html` | `stopAudio()` now suspends `audioCtx`; added `visibilitychange` and `beforeunload` listeners |

---

## Testing Checklist

- [ ] Play ambient audio → Pause → verify Audio thread is not active in DevTools Performance panel
- [ ] Toggle Play/Pause 20 times → verify memory footprint stays flat
- [ ] Switch to another tab while playing → verify audio suspends; return → verify it resumes
- [ ] Navigate away from `focus.html` → verify no AudioContext threads remain in DevTools
- [ ] Change theme while playing → confirm audio restarts cleanly on the reused context
- [ ] Volume slider still works correctly after pause/resume cycle

---

## Notes for Reviewers

- `audioCtx` is intentionally **not** closed on pause — closing would require full reconstruction on every play press, which is heavier than a suspend/resume cycle.
- The `beforeunload` handler covers the only case where the context should be fully destroyed.
- All `.catch()` calls are defensive; failures are silently ignored on `visibilitychange`/`beforeunload` since the page is being torn down anyway.
