### PR TITLE
fix: ensure high scores default to 0 on parsing error

### DIFF
--- a/Games.js
+++ b/Games.js
@@ -1,6 +1,7 @@
 /* ===== GLOBAL STATE ===== */
 const _S = window.TaskQuestStorage;
 let globalScore = _S ? _S.getCoins() : 0;
+if (isNaN(globalScore)) globalScore = 0;
 let globalStreak = _S ? _S.getStreak() : 0;
 
 function addScore(n){


### PR DESCRIPTION
# Related Issue
Closes #455 

# Summary
Fixes potential NaN propagation in scoreboards.

# Changes Made
- Added checks inside `Games.js` to initialize values to `0` if corrupted.

# Testing
Cleared storage manually and verified scores default to numeric `0`.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
