### PR TITLE
style: append focus-visible accessible outline rules

### DIFF
--- a/style.css
+++ b/style.css
@@ -7692,3 +7692,13 @@ body.light .drag-handle:hover {
   align-items: center;
   gap: 8px;
 }
+
+/* Accessibility: Focus-visible states */
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--secondary, #06b6d4);
+  outline-offset: 3px;
+}


### PR DESCRIPTION
# Related Issue
Closes #467 

# Summary
Improves accessibility navigation visuals by adding custom focus rings.

# Changes Made
- Added `:focus-visible` rules for `button`, `a`, `input`, `select`, and `textarea` in `style.css`.

# Testing
Navigated with Tab key; focus indicators render properly in browser.

# Checklist
- [x] Code follows project style
- [x] Tested locally
- [x] No unrelated changes included
