### PR TITLE
docs(security): add responsible disclosure policy

### DIFF
--- a/Security.md
+++ b/Security.md
@@ -68,3 +68,6 @@ We support good-faith security research and will address valid issues responsibl
 ## 🙌 Acknowledgements
 
 We appreciate contributions from the community to improve this project.
+
+## Responsible Disclosure
+If you find a security issue, please report it privately. We aim to respond within 48 hours.


### PR DESCRIPTION
Closes #477 

To foster a secure open-source environment, this PR updates the security policy to explicitly include a Responsible Disclosure timeline.

## Changes Made
- Added a `Responsible Disclosure` section to `Security.md`.
- Stated an expected 48-hour response SLA for private vulnerability reports.

## Related Issues
Fixes the ambiguity around security reporting timelines for external researchers.
