### PR TITLE
docs(terms): add limitation of liability clause

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -108,3 +108,4 @@
   </script>
 </body>
 </html>
+<footer><p><strong>Limitation of Liability:</strong> We shall not be held liable for any indirect damages.</p></footer>


### PR DESCRIPTION
Closes #487 

## Description
This PR enhances the legal robustness of the Terms of Service by introducing a standard Limitation of Liability clause. This ensures contributors and maintainers are protected from indirect damages.

## Changes Made
- Added a new clause in the footer of `terms.html` outlining the limitation of liability.

## Related Issues
Addresses missing legal safeguards in the Terms of Service.
