### PR TITLE
docs(docs): add api reference placeholder section

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -114,3 +114,8 @@
   </script>
 </body>
 </html>
+
+<section id="api-reference">
+  <h2>API Reference</h2>
+  <p>API documentation will be available in future releases.</p>
+</section>


### PR DESCRIPTION
Closes #493 

## Description
As the project scales, developers will look for API endpoints or local storage API schemas. This PR adds a placeholder section to the documentation to set expectations.

## Changes Made
- Added an `<section id="api-reference">` to `docs.html` indicating that API documentation is planned for future releases.

## Related Issues
Addresses missing documentation structure for advanced developer integrations.
