### PR TITLE
docs(changelog): add semver rules explanation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,6 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) co
 | ❌ Removed | Features removed |
 | 🔒 Security | Security patches |
 | ⚠️ Deprecated | Features marked for removal |
+
+## Versioning Strategy
+This project adheres to [Semantic Versioning](https://semver.org/).


### PR DESCRIPTION
Closes #495 

## Description
This PR explicitly declares the project's versioning strategy in the CHANGELOG to prevent confusion during major updates and breaking changes.

## Changes Made
- Added a `Versioning Strategy` section at the top of `CHANGELOG.md`.
- Linked directly to the SemVer specification.

## Related Issues
Fixes ambiguity regarding how version numbers (MAJOR.MINOR.PATCH) are incremented in the project.
