### PR TITLE
fix: normalise vault dates to local YYYY-MM-DD in calcStreak to fix timezone drift

### DIFF
--- a/Reflection.html
+++ b/Reflection.html
@@ -1407,10 +1407,31 @@ function restoreEntry(id) {
 ══════════════════════════════════════════════════════════ */
 function calcStreak() {
   if (!vault.length) return 0;
-  const days = new Set(vault.map(e => new Date(e.date).toDateString()));
+
+  // Entries are stored as UTC ISO strings (new Date().toISOString()).
+  // toDateString() converts to local timezone, so a session saved at
+  // 23:00 UTC by a UTC+5:30 user is attributed to the *next* local day,
+  // inflating the streak. Conversely, a session saved just before local
+  // midnight may be attributed to the previous UTC day, breaking a
+  // genuine streak.
+  //
+  // Fix: normalise every date to a local YYYY-MM-DD string so both the
+  // vault set and the walk-back cursor use the same local calendar day.
+  function toLocalDateKey(dateStr) {
+    const d = new Date(dateStr);
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  }
+
+  const days = new Set(vault.map(e => toLocalDateKey(e.date)));
   let streak = 0;
-  const d = new Date();
-  while (days.has(d.toDateString())) { streak++; d.setDate(d.getDate() - 1); }
+  const cursor = new Date();
+  while (days.has(toLocalDateKey(cursor.toISOString()))) {
+    streak++;
+    cursor.setDate(cursor.getDate() - 1);
+  }
   return streak;
 }
 


### PR DESCRIPTION
#632 
Vault entries are stored as UTC ISO strings via new Date().toISOString(). calcStreak() converted them back with new Date(e.date).toDateString(), which uses the local timezone. For a user in UTC+5:30, a session saved at 23:00 UTC is stored as e.g. '2025-01-15T23:00:00.000Z' but renders as 'Thu Jan 16 2025' in local time. The streak walk-back cursor also used toDateString() on a local Date object.

This mismatch caused two failure modes:
1. A session saved just after local midnight but before UTC midnight is attributed to the previous UTC day, breaking a genuine daily streak.
2. Two sessions saved on the same UTC day but across a local midnight boundary are counted as two separate streak days, inflating the streak and awarding incorrect XP rewards.

Fix: introduce toLocalDateKey() which converts any date string to a local YYYY-MM-DD string using getFullYear/getMonth/getDate (all local). Apply it to both the vault Set construction and the walk-back cursor so both sides of the comparison always use the same local calendar day, eliminating the UTC/local timezone mismatch entirely.
