### PR TITLE
fix: implement null-safety guards in quest analytics parsers

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -17,6 +17,7 @@
   let trendMode = "weekly";
 
   function parseQuestDate(quest, field) {
+    if (!quest) return null;
     const v = quest[field];
     if (!v) return null;
     const d = new Date(v);
@@ -32,6 +33,7 @@
   }
 
   function normalizeQuest(raw) {
+    if (!raw) return { text: "", title: "", category: "General", completed: false, createdAt: new Date().toISOString(), completedAt: null };
     const q = { ...raw };
     q.text = (q.text || q.title || "").trim();
     q.title = q.title || q.text;


### PR DESCRIPTION
# Related Issue
Closes #663 

# Summary
Guards analytics loops from null value errors.

# Changes Made
- Added parameter checks in `parseQuestDate` and `normalizeQuest` inside `analytics.js`.

# Testing
- Cleared LocalStorage keys and confirmed dashboard loads without script crashes.

# Impact
Improves robustness of the analytics views.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
