### PR TITLE
refactor: optimize earned badge lookups with O(1) BADGE_LOOKUP dictionary

### DIFF
--- a/badges.js
+++ b/badges.js
@@ -11,6 +11,15 @@
     { id: 'zero_overdue_week', title: 'Zero Overdue Week', icon: '🚀', desc: 'No missed days in the last 7 days.' },
   ];
 
+  const BADGE_LOOKUP = BADGES.reduce((acc, b) => {
+    acc[b.id] = b;
+    return acc;
+  }, {});
+
+  function getBadgeById(id) {
+    return BADGE_LOOKUP[id] || { id, title: 'Unknown Badge', icon: '❓', desc: 'No description available.' };
+  }
+
   function loadUnlocked() {
     try {
       return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
@@ -115,7 +124,7 @@
       // render and notify
       renderBadges(unlocked);
       changed.forEach(id => {
-        const b = BADGES.find(x=>x.id===id);
+        const b = getBadgeById(id);
         try { window.showToast(`Unlocked badge: ${b.title} ${b.icon}`, 'success'); } catch(e){}
       });
     } else {


### PR DESCRIPTION
# Related Issue
Closes #667 

# Summary
Optimizes badge metadata lookup logic to use dictionary mapping.

# Changes Made
- Declared `BADGE_LOOKUP` in `badges.js`.
- Refactored lookup routines to use `getBadgeById()`.

# Testing
- Verified badge toasts load metadata correctly upon unlocking.

# Impact
Reduces unnecessary array loops.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
