### PR TITLE
fix: enforce validation preventing past due dates on new tasks

### DIFF
--- a/script.js
+++ b/script.js
@@ -1414,6 +1414,15 @@ function addTask() {
   }
   taskInput.setAttribute("aria-invalid", "false");
 
+  if (deadline) {
+    const selectedDate = new Date(deadline);
+    if (selectedDate < new Date()) {
+      if (window.showToast) window.showToast("Cannot set a deadline in the past.", "error");
+      else alert("Cannot set a deadline in the past.");
+      return;
+    }
+  }
+
   const task = {
     id: Date.now(),
     text,


### PR DESCRIPTION
# Related Issue
Closes #675 

# Summary
Prevents users from setting active task deadlines in the past.

# Changes Made
- Added a date validation check inside `addTask()` in `script.js`.

# Testing
- Selected yesterday's date in the task form and confirmed the error toast blocks submission.

# Impact
Enforces cleaner input data.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
