### PR TITLE
fix: resolve node_modules find exclusion syntax in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           echo "## Project Files Size Report 📊" >> $GITHUB_STEP_SUMMARY
           echo "| File | Size |" >> $GITHUB_STEP_SUMMARY
           echo "|---|---|" >> $GITHUB_STEP_SUMMARY
-          find . -name "*.html" -o -name "*.css" -o -name "*.js" | not -path "./node_modules/*" | while read file; do
+          find . -type f \( -name "*.html" -o -name "*.css" -o -name "*.js" \) -not -path "*/node_modules/*" | while read file; do
             size=$(ls -lh "$file" | awk '{print $5}')
             echo "| \`$file\` | $size |" >> $GITHUB_STEP_SUMMARY
           done


### PR DESCRIPTION
# Related Issue
Closes #687 

# Summary
Fixes the syntactically invalid find pipe command in the code quality workflow.

# Changes Made
- Modified `.github/workflows/ci.yml` to use correct `find -not -path` syntax instead of the invalid `not` command pipe.

# Testing
- Verified syntax locally.
- Pushed to branch to trigger CI validation.

# Impact
Ensures that the runner pipeline completes cleanly.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
