### PR TITLE
feat: add tooltips for task action buttons

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1549,7 +1549,7 @@ function createTaskEl(task) {
   div.innerHTML = `
     <div class="drag-handle" title="Drag to reorder"><i class="ri-drag-move-fill"></i></div>
     <div class="task-left">
-      <div class="check-btn" tabindex="0" aria-label="Toggle completed task"></div>
+        title="Mark Complete" tabindex="0" aria-label="Toggle completed task"></div>
       <div>
         <h3 class="task-title">${escapeHtml(task.text)}</h3>
         <div style="display: flex; gap: 8px; align-items: center; margin-top: 4px; flex-wrap: wrap;">
@@ -1564,10 +1564,16 @@ function createTaskEl(task) {
       </div>
     </div>
     <div class="task-actions">
-      <button class="icon-btn edit-btn" aria-label="Edit Quest">
+     <button
+  class="icon-btn edit-btn"
+  aria-label="Edit Quest"
+  title="Edit Task">
         <i class="ri-edit-line"></i>
       </button>
-      <button class="icon-btn delete-btn" aria-label="Delete Quest">
+      <button
+  class="icon-btn delete-btn"
+  aria-label="Delete Quest"
+  title="Delete Task">
         <i class="ri-delete-bin-6-line"></i>
       </button>
     </div>


### PR DESCRIPTION
## Issue #1002 – Add Tooltips for Task Action Buttons

### Description

The task management interface contains action buttons such as Edit, Delete, Complete, and other task-related controls. Currently, these buttons rely solely on icons or labels, which may not clearly communicate their purpose to all users.

### Proposed Enhancement

Add descriptive tooltips to all task action buttons. Tooltips should appear when users hover over a button and provide a short explanation of the action being performed.

### Expected Behavior

* Display a tooltip on hover for each task action button.
* Tooltip text should clearly describe the button action.
* Tooltips should be accessible and keyboard-friendly.
* Ensure consistent styling across all task-related actions.

### Example Tooltips

* Edit → "Edit Task"
* Delete → "Delete Task"
* Complete → "Mark as Complete"

### Benefits

* Improves usability and discoverability.
* Enhances accessibility for new users.
* Provides a more polished user experience.
* Reduces ambiguity when icon-only buttons are used.

### Acceptance Criteria

* All task action buttons include tooltips.
* Tooltips appear correctly on hover and keyboard focus.
* Existing functionality remains unchanged.
* UI styling remains consistent with the application design.
