### PR TITLE
feat: disable browser autocomplete for task search

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
         <div class="topbar-right">
           <div class="search-bar-container" style="position: relative; display: flex; align-items: center; margin-right: 15px;">
             <i class="ri-search-line" style="position: absolute; left: 10px; color: var(--text-muted);"></i>
-            <input type="text" id="taskSearchInput" placeholder="Search tasks..." style="padding: 8px 10px 8px 32px; border-radius: 20px; border: 1px solid var(--border); background: var(--card); color: var(--text); outline: none; width: 100%; max-width: 200px; font-size: 0.9rem;">
+            <input type="text" id="taskSearchInput" autocomplete="off" placeholder="Search tasks..." style="padding: 8px 10px 8px 32px; border-radius: 20px; border: 1px solid var(--border); background: var(--card); color: var(--text); outline: none; width: 100%; max-width: 200px; font-size: 0.9rem;">
           </div>
           <div class="theme-selector-panel">
             <button class="theme-dot active" data-theme="cosmic" aria-label="Cosmic Theme" style="background: linear-gradient(135deg, #a855f7, #06b6d4);"></button>


### PR DESCRIPTION
# Pull Request Description

## 🔗 Related Issue

Closes #1075

## Summary

This PR disables browser autocomplete for the task search input. Browser-saved suggestions could overlap with the application's custom search interface and create a distracting user experience. Adding `autoComplete="off"` ensures a cleaner and more consistent search interaction.

## Changes Made

* Added `autoComplete="off"` to the task search input field.
* Prevented browser autocomplete suggestions from appearing during task searches.

## Testing Checklist

### Local Development Testing

* [x] Visual verification of changes in localized pages (e.g. `index.html`, browser tools).
* [x] Console checked for errors/warnings.
* [x] Checked on mobile viewports for responsiveness.

### Automated Checks

* [ ] Run syntax validation: `node --check <modified_js_files>` (if JS modified).

## Screenshots / Demos (If Applicable)

N/A

## Quality Standards Checklist

* [x] The code is clean, documented, and free of commented-out blocks.
* [x] Branch is synced with the latest remote `main`.
* [x] No unrelated modifications or formatting adjustments are included in the diff.
* [x] Accessibilities (e.g. keyboard accessibility, contrast) verified.
